### PR TITLE
MAGE-673 Add missing components as variable for destructured argument.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": [
     "MIT"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "require": {
     "algolia/algoliasearch-magento-2": "^3.9.1",
     "magento/magento-composer-installer": "*"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_CustomAlgolia" setup_version="1.2.1">
+    <module name="Algolia_CustomAlgolia" setup_version="1.2.2">
         <sequence>
             <module name="Algolia_AlgoliaSearch"/>
             <module name="Magento_Theme"/>

--- a/view/frontend/web/hooks.js
+++ b/view/frontend/web/hooks.js
@@ -88,8 +88,8 @@ define(['jquery', 'algoliaAnalytics', 'algoliaBundle', 'suggestionsHtml', 'algol
                             header({html, items}) {
                                 return suggestionsHtml.getHeaderHtml({html});
                             },
-                            item({item, html}) {
-                                return suggestionsHtml.getItemHtml({item, html})
+                            item({item, components, html}) {
+                                return suggestionsHtml.getItemHtml({item, components, html})
                             },
                             footer({html, items}) {
                                 return suggestionsHtml.getFooterHtml({html})


### PR DESCRIPTION
This PR corrects the missing `components` variable in the sample query suggestions plugin.