### PR TITLE
Feature/mage 1015 bundle stuffing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
   "license": [
     "MIT"
   ],
-  "version": "1.3.0",
+  "version": "1.4.0",
   "require": {
-    "algolia/algoliasearch-magento-2": "^3.14.0",
+    "algolia/algoliasearch-magento-2": "^3.15.0",
     "magento/magento-composer-installer": "*"
   },
   "extra": {

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -61,7 +61,12 @@ const config = {
             // Uncomment the following mixin to change the template parsing engine from Mustache to Hogan
             // "Algolia_AlgoliaSearch/js/internals/template-engine": {
             //     "Algolia_CustomAlgolia/js/internals/template-engine-mixin": true,
+            // },
+
+            // Uncomment the following mixin to add libraries to the algoliaBundle used in front end hooks (Legacy support feature)
+            // "Algolia_AlgoliaSearch/js/instantsearch": {
+            //     "Algolia_CustomAlgolia/js/instantsearch-mixin": true,
             // }
         },
-    },
+    }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -42,9 +42,9 @@ const config = {
     config: {
         mixins: {
             // Uncomment the following mixins to override the hit template via a JavaScript mixin for a given source
-            "Algolia_AlgoliaSearch/js/template/autocomplete/products": {
-              "Algolia_CustomAlgolia/js/template/autocomplete/products-mixin": true,
-            }
+            // "Algolia_AlgoliaSearch/js/template/autocomplete/products": {
+            //   "Algolia_CustomAlgolia/js/template/autocomplete/products-mixin": true,
+            // },
             // "Algolia_AlgoliaSearch/js/template/autocomplete/categories": {
             //   "Algolia_CustomAlgolia/js/template/autocomplete/categories-mixin": true,
             // },
@@ -57,6 +57,11 @@ const config = {
             // "Algolia_AlgoliaSearch/js/template/autocomplete/suggestions": {
             //   "Algolia_CustomAlgolia/js/template/autocomplete/suggestions-mixin": true,
             // },
+
+            // Uncomment the following mixin to change the template parsing engine from Mustache to Hogan
+            // "Algolia_AlgoliaSearch/js/internals/template-engine": {
+            //     "Algolia_CustomAlgolia/js/internals/template-engine-mixin": true,
+            // }
         },
     },
 };

--- a/view/frontend/web/js/instantsearch-mixin.js
+++ b/view/frontend/web/js/instantsearch-mixin.js
@@ -1,0 +1,18 @@
+// SAMPLE INSTANTSEARCH MIXIN
+define(['uiComponent', 'algoliaHoganLib'], function (Component, Hogan) {
+    "use strict";
+
+    return function (target) {
+        // Demonstrates how to load legacy bundle with additional libs for older front end hook API
+        const mixin = {
+            mockAlgoliaBundle: function () {
+                console.log("Customizing the algoliaBundle...");
+                const algoliaBundle = this._super();
+                algoliaBundle.Hogan = Hogan;
+                return algoliaBundle;
+            },
+        };
+
+        return target.extend(mixin);
+    };
+});

--- a/view/frontend/web/js/internals/template-engine-mixin.js
+++ b/view/frontend/web/js/internals/template-engine-mixin.js
@@ -1,0 +1,14 @@
+// SAMPLE TEMPLATE ENGINE MIXIN
+define(function () {
+    "use strict";
+
+    return function (target) {
+        const mixin = {
+            getSelectedEngineType: function () {
+                return target.ENGINE_TYPE_HOGAN;
+            },
+        };
+
+        return { ...target, ...mixin };
+    };
+});


### PR DESCRIPTION
The removal of `algoliaBundle` creates some interesting scenarios for certain edge cases, but we have provided workarounds which are demonstrated here.

Example mixins supplied to customize:
- What templating parser is used for Algolia InstantSearch layout and rendering
- What libraries should be available to front end events that [previously expected](https://www.algolia.com/doc/integration/magento-2/customize/custom-front-end-events/?client=php#instantsearch-page-events) `algoliaBundle` as an argument. (NOW DEPRECATED)

It makes no sense to download libraries to the browser which should not be used and in general it is recommended to load additional legacy bundle libraries globally but in case customizations depend on the old API this provides another option. 

Note that this update depends on changes in this PRI: https://github.com/algolia/algoliasearch-magento-2/pull/1608